### PR TITLE
remove -Wno-unused-result from test compilation commands

### DIFF
--- a/tests/run.scm
+++ b/tests/run.scm
@@ -5,14 +5,12 @@
 	 "cncb-simple-test.scm")
 	(run (csc			;-k -C -g
 	      simple-test.c -o test1
-	      -C -Wno-unused-result
 	      cncb-simple-test.scm -e
 	      -lpthread)))
        ("test2" ("hammering.c" 
 		 "cncb-simple-test.scm")
 	(run (csc			;-k -C -g
 	      hammering.c -o test2
-	      -C -Wno-unused-result
 	      cncb-simple-test.scm -e
 	      -lpthread))))
   '("test1" "test2"))


### PR DESCRIPTION
This just removes the same flag as 151b3ba from the tests, for older GCCs.
